### PR TITLE
Parse relative retry-after correctly

### DIFF
--- a/http.go
+++ b/http.go
@@ -112,7 +112,7 @@ func parseRetryAfter(retryAfter string) (time.Duration, error) {
 	// Assuming that the header contains seconds instead of a date
 
 	// Try parsing seconds first:
-	if d, err := time.ParseDuration(retryAfter); err == nil {
+	if d, err := time.ParseDuration(fmt.Sprintf("%vs", retryAfter)); err == nil {
 		return d, nil
 	}
 

--- a/http_test.go
+++ b/http_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -141,6 +142,12 @@ var _ = Describe("HTTP Client", func() {
 			json.Unmarshal([]byte(expectedResp), &expResp)
 			Expect(authHeader).To(Equal("key=apiKey"))
 			Expect(resp).To(Equal(&expResp))
+		})
+	})
+
+	Context("parseRetryAfter", func() {
+		It("should parse 10 correctly", func() {
+			Expect(parseRetryAfter("10")).To(Equal(time.Second * 10))
 		})
 	})
 })


### PR DESCRIPTION
In testing, I noticed that seconds values like "10" did not parse correctly - this rectifies that.