### PR TITLE
Fix GCM XMPP client create from hanging

### DIFF
--- a/client.go
+++ b/client.go
@@ -157,7 +157,7 @@ func (c *gcmClient) monitorXMPP(activeMonitor bool) {
 			xc = c.xmppClient
 		} else {
 			xc = nil
-			cerr = make(chan error)
+			cerr = make(chan error, 1)
 		}
 
 		// Create XMPP client.


### PR DESCRIPTION
If the client creation fails (not during the first run) then the code will currently hang. This change will prevent this from happening. The reason it is hanging is because nothing is reading from cerr so when an error is being written to the channel it blocks forever. If we make the channel buffered (only size of 1 is necessary) then it will no longer block forever.

Fixes #26